### PR TITLE
Feat: Add dynamic tab titles and home button

### DIFF
--- a/CutieBrowser.py
+++ b/CutieBrowser.py
@@ -7,9 +7,9 @@ Created on Sun Apr 21 10:07:22 2024
 
 import sys
 import logging # Added for logging
-from PyQt5.QtWidgets import QApplication, QMainWindow, QLineEdit, QTabWidget, QVBoxLayout, QWidget, QAction, QFileDialog, QMessageBox
+from PyQt5.QtWidgets import QApplication, QMainWindow, QLineEdit, QTabWidget, QVBoxLayout, QWidget, QAction, QFileDialog, QMessageBox, QPushButton, QHBoxLayout
 from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
-from PyQt5.QtCore import QUrl, QCoreApplication
+from PyQt5.QtCore import QUrl, QCoreApplication, Qt
 
 class CutieBrowser(QMainWindow):
     def __init__(self):
@@ -17,6 +17,8 @@ class CutieBrowser(QMainWindow):
 
         self.setWindowTitle("Cutie Browser")
         self.setGeometry(100, 100, 800, 600)
+
+        self.DEFAULT_HOME_URL = "https://www.google.com"
 
         self.central_widget = QWidget()
         self.layout = QVBoxLayout()
@@ -26,20 +28,99 @@ class CutieBrowser(QMainWindow):
         self.tabs = QTabWidget()
         self.layout.addWidget(self.tabs)
 
-        self.add_tab("https://www.google.com") # This will also log
+        # Add 'New Tab' button
+        new_tab_button = QPushButton("+")
+        new_tab_button.setMaximumWidth(30)
+        new_tab_button.clicked.connect(lambda: self.add_tab()) # Connect to existing add_tab
+        self.tabs.setCornerWidget(new_tab_button, Qt.TopRightCorner)
+
+        # Enable closable tabs
+        self.tabs.setTabsClosable(True)
+        self.tabs.tabCloseRequested.connect(self.close_tab)
+        self.tabs.currentChanged.connect(self.update_navigation_buttons) # Update nav buttons on tab change
+
+        # Navigation buttons
+        nav_layout = QHBoxLayout()
+        self.back_button = QPushButton("<-")
+        self.back_button.clicked.connect(self.go_back)
+        self.forward_button = QPushButton("->")
+        self.forward_button.clicked.connect(self.go_forward)
+        self.refresh_button = QPushButton("R")
+        self.refresh_button.clicked.connect(self.refresh_page)
+        self.home_button = QPushButton("Home") # Create Home button
+        self.home_button.clicked.connect(self.go_home) # Connect Home button
+
+        nav_layout.addWidget(self.back_button)
+        nav_layout.addWidget(self.forward_button)
+        nav_layout.addWidget(self.refresh_button)
+        nav_layout.addWidget(self.home_button) # Add Home button to layout
+        self.layout.addLayout(nav_layout) # Add nav buttons layout
 
         self.url_bar = QLineEdit()
         self.url_bar.returnPressed.connect(self.navigate_to_url)
         self.layout.addWidget(self.url_bar)
 
+        self.add_tab("https://www.google.com") # This will also log
+
         self.init_menu_bar()
+        self.update_navigation_buttons() # Initial state update
         # logging.info("CutieBrowser window initialized") # Optional, app start is logged
+
+    def go_back(self):
+        current_browser = self.tabs.currentWidget()
+        if current_browser:
+            logging.info("Navigating back")
+            current_browser.back()
+
+    def go_forward(self):
+        current_browser = self.tabs.currentWidget()
+        if current_browser:
+            logging.info("Navigating forward")
+            current_browser.forward()
+
+    def refresh_page(self):
+        current_browser = self.tabs.currentWidget()
+        if current_browser:
+            logging.info("Refreshing page")
+            current_browser.reload()
+
+    def go_home(self):
+        current_browser = self.tabs.currentWidget()
+        if current_browser:
+            logging.info(f"Navigating current tab to home page: {self.DEFAULT_HOME_URL}")
+            current_browser.setUrl(QUrl(self.DEFAULT_HOME_URL))
+        else:
+            logging.info("Home button clicked but no active tab to navigate.")
+            # Optionally, open a new tab with the home page if no tab is active
+            # self.add_tab(self.DEFAULT_HOME_URL)
+
+    def update_navigation_buttons(self):
+        current_browser = self.tabs.currentWidget()
+        if current_browser:
+            self.back_button.setEnabled(current_browser.page().action(QWebEnginePage.Back).isEnabled())
+            self.forward_button.setEnabled(current_browser.page().action(QWebEnginePage.Forward).isEnabled())
+            self.refresh_button.setEnabled(True)
+            self.home_button.setEnabled(True)
+        else:
+            self.back_button.setEnabled(False)
+            self.forward_button.setEnabled(False)
+            self.refresh_button.setEnabled(False)
+            self.home_button.setEnabled(False)
+
+    def close_tab(self, index):
+        logging.info(f"Closing tab at index {index}")
+        widget = self.tabs.widget(index)
+        if widget:
+            widget.deleteLater()
+        self.tabs.removeTab(index)
+        self.update_navigation_buttons() # Update nav buttons after closing a tab
 
     def add_tab(self, url=None):
         browser = QWebEngineView()
         browser.setPage(QWebEnginePage())
         browser.loadFinished.connect(lambda ok, b=browser: self.handle_load_finished(ok, b))
-        browser.page().urlChanged.connect(lambda url, browser=browser: self.update_url_bar(url, browser))
+        browser.page().urlChanged.connect(lambda url, b=browser: self.update_url_bar(url, b)) # Pass browser instance
+        browser.page().titleChanged.connect(lambda title, b=browser: self.handle_title_changed(title, b)) # Connect titleChanged
         browser.page().profile().downloadRequested.connect(self.download_requested)
 
         if url:
@@ -51,6 +132,7 @@ class CutieBrowser(QMainWindow):
             # browser.load(QUrl("about:blank")) # Or your preferred default
 
         self.tabs.addTab(browser, "New Tab") # Add tab after attempting to load URL or setting default
+        self.update_navigation_buttons() # Update nav buttons after adding a new tab
 
     def navigate_to_url(self):
         url = self.url_bar.text()
@@ -60,12 +142,21 @@ class CutieBrowser(QMainWindow):
             logging.info(f"URL modified to: {url}") # Log modification
         self.add_tab(url) # add_tab will log the specifics of adding the tab
 
-    def update_url_bar(self, url, browser):
-        index = self.tabs.indexOf(browser)
+    def update_url_bar(self, url, browser): # browser argument is kept for consistency if ever needed, but not used for tab text
+        # index = self.tabs.indexOf(browser) # No longer setting tab text here
         # It's possible the tab is closed before this callback, check index
-        if index != -1:
-            self.tabs.setTabText(index, url.toString())
+        # if index != -1:
+            # self.tabs.setTabText(index, url.toString()) # Removed: Tab text is handled by titleChanged
         self.url_bar.setText(url.toString())
+
+    def handle_title_changed(self, title, browser_instance):
+        index = self.tabs.indexOf(browser_instance)
+        if index != -1:
+            self.tabs.setTabText(index, title)
+            logging.info(f"Tab title changed to: {title} for tab index {index}")
+        else:
+            logging.warning(f"Could not find tab for title change: {title}")
+
 
     def download_requested(self, download):
         file_path, _ = QFileDialog.getSaveFileName(self, "Save File", "", "All Files (*)")
@@ -106,6 +197,14 @@ class CutieBrowser(QMainWindow):
             QMessageBox.warning(self, "Load Error", f"Failed to load page: {page_url}. Please check the URL and your internet connection.")
         else:
             logging.info(f"Successfully loaded page: {page_url}")
+            # Fallback to set tab title if titleChanged didn't fire or for initial set
+            index = self.tabs.indexOf(browser_instance)
+            if index != -1:
+                page_title = browser_instance.page().title()
+                if page_title and page_title != "New Tab": # Avoid replacing "New Tab" if title is empty
+                    self.tabs.setTabText(index, page_title)
+                    logging.info(f"Tab title set on load finished: {page_title} for tab index {index}")
+        self.update_navigation_buttons() # Update nav buttons after page load attempt
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Cutie Browser is a simple, lightweight web browser built with Python and the PyQ
 ## Features
 
 *   Tabbed browsing
+    *   Enhanced tab management:
+        *   Dedicated 'New Tab' (+) button.
+        *   Tabs are closable with an 'x' button.
+        *   Tab titles now display the actual web page title for better identification.
+*   Navigation controls:
+    *   Back, Forward, and Refresh buttons for web page navigation.
+    *   Home button to quickly navigate to a default homepage.
 *   URL navigation with defaulting to HTTPS
 *   Basic error handling for page loads
 *   File downloads
@@ -38,6 +45,49 @@ Cutie Browser is a simple, lightweight web browser built with Python and the PyQ
     ```bash
     python CutieBrowser.py
     ```
+
+## Building an Executable
+
+You can package Cutie Browser into a standalone executable using PyInstaller. This allows users to run the browser without needing to install Python or the required dependencies.
+
+1.  **Install PyInstaller:**
+    ```bash
+    pip install pyinstaller
+    ```
+
+2.  **Package the application:**
+
+    *   **For a single file executable (simpler distribution, potentially slower startup):**
+        ```bash
+        pyinstaller --onefile --windowed --name CutieBrowser CutieBrowser.py
+        ```
+    *   **For a one-folder bundle (faster startup, results in a folder with multiple files):**
+        ```bash
+        # pyinstaller --windowed --name CutieBrowser CutieBrowser.py
+        ```
+        (Note: The one-folder command is often just `pyinstaller --windowed CutieBrowser.py` if the name matches the script, but `--name` can be explicit.)
+
+### Troubleshooting & Considerations
+
+*   **Platform Specificity:** An executable built on one OS (e.g., Windows) will only run on that OS. You'll need to build separately for Windows, macOS, and Linux.
+*   **File Size:** Executables including PyQtWebEngine can be quite large due to the bundled browser engine.
+*   **PyQtWebEngine Issues:** Packaging PyQtWebEngine can sometimes be complex. If the application doesn't start or browser functionality is broken after packaging, you might need to:
+    *   Examine PyInstaller's build warnings in the console for clues.
+    *   Manually specify paths to QtWebEngine components using PyInstaller's `--add-binary` option (or `--add-data` for non-binary files) or by modifying the `.spec` file. This is often necessary to ensure all required Qt plugins and processes are included. For example, you might need to include `QtWebEngineProcess` or specific Qt plugins. An illustrative (and might need adjustment based on your OS and environment) command could look like:
+        ```bash
+        # Example for Windows: Adjust paths based on your environment (esp. venv location)
+        # You may need to find the exact location of these files in your PyQt5 installation.
+        pyinstaller --onefile --windowed --name CutieBrowser \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/bin/QtWebEngineProcess.exe:." \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/resources:resources" \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/translations:translations" \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/plugins/platforms:platforms" \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/plugins/imageformats:imageformats" \
+          --add-binary="path/to/your/venv/Lib/site-packages/PyQt5/Qt5/plugins/webenginewidgets:webenginewidgets" \
+          CutieBrowser.py
+        ```
+    *   Replace `path/to/your/venv` with the actual path to your virtual environment's `site-packages` directory, or the global site-packages directory if not using a virtual environment. The exact paths and required Qt components (like DLLs, .so files, or .dylib files) can vary significantly between operating systems and PyQt5 versions. Consult PyInstaller and PyQt documentation for advanced troubleshooting and specifics for your OS.
+*   **Spec File:** For more complex scenarios or fine-grained control, you can first generate a `.spec` file (`pyi-makespec CutieBrowser.py`) and then edit it to include specific hooks, binaries, or data files before building with PyInstaller (`pyinstaller CutieBrowser.spec`).
 
 ## Contributing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyQt5
-PyQtWebEngine
+PyQt5==5.15.10
+PyQtWebEngine==5.15.6


### PR DESCRIPTION
This commit introduces two user experience improvements:

1.  **Dynamic Tab Titles:** Tabs now display the actual title of the loaded web page instead of the URL. This makes it easier for you to identify and switch between open tabs. The title updates dynamically if the page's title changes.

2.  **Home Button:** A 'Home' button has been added to the navigation controls. Clicking this button navigates the current tab to a predefined default homepage (currently Google.com).

The README has been updated to include these new features.